### PR TITLE
validation for creating customer and products now working

### DIFF
--- a/Controllers/CustomerController.cs
+++ b/Controllers/CustomerController.cs
@@ -43,10 +43,17 @@ namespace Bangazon.Controllers
 
         public async Task<IActionResult> Create(Customer customer)
         {
+            CreateCustomerViewModel model = new CreateCustomerViewModel(context); 
+
+             if (ModelState.IsValid)
+            {
             context.Add(customer);
             await context.SaveChangesAsync();
             Activate(customer.CustomerId);
             return RedirectToAction("Index", "Products");
+            }
+            return View(model);
+
         }
         //Method: Purpose is to create a new instance of the ActiveCustomer class based on the customerId selected in the dropdown method. Accepts an argument, passed in through route/URL of an integer (the selected customer's primary key/id)
         [HttpPost]

--- a/Views/Customers/Create.cshtml
+++ b/Views/Customers/Create.cshtml
@@ -8,6 +8,8 @@ Model (capital "m") references the instantiation of the model.*@
 <h2>@ViewData["Title"]</h2>
 
 <form asp-action="Create">
+     @Html.ValidationSummary()
+
     <div class="form-horizontal">
         <hr />
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>

--- a/Views/Products/Create.cshtml
+++ b/Views/Products/Create.cshtml
@@ -7,6 +7,8 @@
 <h2>@ViewData["Title"]</h2>
 
 <form asp-action="Create">
+    @Html.ValidationSummary()
+
     <div class="form-horizontal">
         <hr />
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -64,6 +64,9 @@
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
         </script>
         <script src="~/js/site.min.js" asp-append-version="true"></script>
+                <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.11.3.min.js"></script>
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"></script>
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery.validation.unobtrusive/3.2.6/jquery.validate.unobtrusive.min.js"></script>  
     </environment>
 
     @RenderSection("scripts", required: false)


### PR DESCRIPTION
Forms to create a new customer and a new product now display error messages when all the fields aren't filled out. 

Files updated: 
Controllers/CustomerController.cs 
Views/Customers/Create.cshtml 
Views/Products/Create.cshtml 
Views/Shared/_Layout.cshtml

TO TEST:
git fetch 
git checkout dy-validate 

1. attempt to create a customer and don't fill out a field. You should get an error message at the top detailing the error.
2. attempt to add a product and don't fill out a field. You should get an error message at the top detailing the error. 